### PR TITLE
Helper functions to convert GeoJSON to array and back

### DIFF
--- a/helpers/array-to-geojson.js
+++ b/helpers/array-to-geojson.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = arrayToGeojson;
+
+function arrayToGeojson(arrays) {
+    var features = [];
+    arrays.forEach(function (array) {
+        var feature = {
+            'type': 'Feature',
+            'properties': {},
+            'geometry': {
+                'type': 'LineString',
+                'coordinates': array
+            }
+        };
+        features.push(feature);
+    });
+    return {
+        'type': 'FeatureCollection',
+        'features': features
+    };
+}

--- a/helpers/geojson-to-array.js
+++ b/helpers/geojson-to-array.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = geojsonToArray;
+
+function geojsonToArray(jsonData) {
+    var arrays = [];
+    jsonData.features.forEach(function (feature) {
+        arrays.push(feature.geometry.coordinates);
+    });
+    return arrays;
+}


### PR DESCRIPTION
Following helper functions are useful while working with `linematch`:
- GeoJSON to array
- Array to GeoJSON

@mourner Is `helpers/` a good place for this?
